### PR TITLE
Updated gt keyword to use * wildcards in search

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,10 @@ class KeywordQueryEventListener(EventListener):
         
         else:
             if keyword == 'gt':
+		if " " in query_words: 
+			query_words = "*".join(query_words.split(' ')) + "*"
+		else:
+			query_words = query_words + "*"
                 command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
                 output = subprocess.check_output(command)          
                 pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]


### PR DESCRIPTION
Fantastic extension, I use it all the time! At the moment, though, the gnome-tracker gt search does not find partial matches for me, but only finds the file if there's a complete match.
Have added 4 lines to insert * wildcards into any spaces in the query_words string so that tracker finds also partial matches. Works quite well for me. Would be great if could integrate into main branch if it works for you.