### PR TITLE
Allow customising text editor, file browser from preferences 

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,8 +126,8 @@ class ItemEnterEventListener(EventListener):
         appchooser_path = appPath + '/appchooser.py'
         options = [['Open with default application', 'xdg-open','images/detective_penguin.png'],
                    ['Open with other application', appchooser_path, other_application_icon],
-                   ['Open with file browser', 'nautilus', file_browser_icon],
-                   ['Open with text editor', 'gedit', text_editor_icon],
+                   ['Open with file browser', extension.preferences["filebrowser"], file_browser_icon],
+                   ['Open with text editor', extension.preferences["texteditor"], text_editor_icon],
                    ['Open location in terminal', 'gnome-terminal --working-directory', terminal_icon]]
         data = event.get_data().replace("%20"," ")
         items = []

--- a/main.py
+++ b/main.py
@@ -73,6 +73,10 @@ class KeywordQueryEventListener(EventListener):
         
         else:
             if keyword == preferences["gt_kw"]:
+                if " " in query_words: 
+                    query_words = "*".join(query_words.split(' ')) + "*"
+                else:
+                    query_words = query_words + "*"
                 command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
                 output = subprocess.check_output(command)          
                 pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ class ItemEnterEventListener(EventListener):
         data = event.get_data().replace("%20"," ")
         items = []
         for i in options:
-            if i[2] == 'gnome-terminal':
+            if i[2] == 'terminal':
                 data = os.path.dirname(os.path.abspath(data))
             items.append(ExtensionResultItem(icon=i[2],
                                              name='%s' %i[0],

--- a/main.py
+++ b/main.py
@@ -73,10 +73,6 @@ class KeywordQueryEventListener(EventListener):
         
         else:
             if keyword == preferences["gt_kw"]:
-                if " " in query_words: 
-                    query_words = "*".join(query_words.split(' ')) + "*"
-                else:
-                    query_words = query_words + "*"
                 command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
                 output = subprocess.check_output(command)          
                 pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ class ItemEnterEventListener(EventListener):
         data = event.get_data().replace("%20"," ")
         items = []
         for i in options:
-            if i[2] == 'terminal':
+            if i[2] == 'gnome-terminal':
                 data = os.path.dirname(os.path.abspath(data))
             items.append(ExtensionResultItem(icon=i[2],
                                              name='%s' %i[0],

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,20 @@
       "name": "locate",
       "description": "Instantly find files using locate command",
       "default_value": "lc"
+    },
+    {
+      "id": "filebrowser",
+      "type": "input",
+      "name": "Default File Browser",
+      "description": "default is 'nautilus', but you can change this to use a different file manager you have installed.",
+      "default_value": "nautilus"
+    },
+    {
+      "id": "texteditor",
+      "type": "input",
+      "name": "Default Text Editor",
+      "description": "Default is 'gedit', but you can change this to point to any other text editor you have installed",
+      "default_value": "gedit"
     }
   ]
 }


### PR DESCRIPTION
Just a small feature addition to allow changing the default file manager and text editor from nautilus and gedit from the preferences. Shouldn't change the basic functionality and config at all, but for people who use something other than gedit or nautilus it could be useful (though sadly some file managers like spacefm, don't work properly with the full path with filename).

Was thinking about using 'xdg-mime query default text/text' to get the system default of the text editor, for instance, but I thought this could be faster, and easier for users to configure.