### PR TITLE
Fixed gnome-terminal folder bug + added optional wildcard preferences setting

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,8 +126,8 @@ class ItemEnterEventListener(EventListener):
         appchooser_path = appPath + '/appchooser.py'
         options = [['Open with default application', 'xdg-open','images/detective_penguin.png'],
                    ['Open with other application', appchooser_path, other_application_icon],
-                   ['Open with file browser', 'nautilus', file_browser_icon],
-                   ['Open with text editor', 'gedit', text_editor_icon],
+                   ['Open with file browser', extension.preferences["filebrowser"], file_browser_icon],
+                   ['Open with text editor', extension.preferences["texteditor"], text_editor_icon],
                    ['Open location in terminal', 'gnome-terminal --working-directory', terminal_icon]]
         data = event.get_data().replace("%20"," ")
         items = []

--- a/main.py
+++ b/main.py
@@ -73,6 +73,10 @@ class KeywordQueryEventListener(EventListener):
         
         else:
             if keyword == preferences["gt_kw"]:
+                if " " in query_words: 
+                    query_words = "*".join(query_words.split(' ')) + "*"
+                else:
+                    query_words = query_words + "*"
                 command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
                 output = subprocess.check_output(command)          
                 pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]

--- a/main.py
+++ b/main.py
@@ -73,10 +73,6 @@ class KeywordQueryEventListener(EventListener):
         
         else:
             if keyword == preferences["gt_kw"]:
-                if " " in query_words: 
-                    query_words = "*".join(query_words.split(' ')) + "*"
-                else:
-                    query_words = query_words + "*"
                 command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
                 output = subprocess.check_output(command)          
                 pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ class ItemEnterEventListener(EventListener):
         data = event.get_data().replace("%20"," ")
         items = []
         for i in options:
-            if i[2] == 'terminal':
+            if i[2] == 'gnome-terminal':
                 data = os.path.dirname(os.path.abspath(data))
             items.append(ExtensionResultItem(icon=i[2],
                                              name='%s' %i[0],

--- a/main.py
+++ b/main.py
@@ -114,7 +114,7 @@ class KeywordQueryEventListener(EventListener):
                         results = [[os.path.basename(i),i] for i in pre_results]
                 # Do auto wildcard search if enabled in preferences
                 else:
-                    output = subprocess.check_output(['locate','-i','-l','11','--regexp', ".*".join(words)])
+                    output = subprocess.check_output(['locate','-i','-l','11', "*" + "*".join(words) + "*"])
                     pre_results = output.splitlines() 
                     results = [[os.path.basename(i),i] for i in pre_results]
 

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,20 @@
       "name": "locate",
       "description": "Instantly find files using locate command",
       "default_value": "lc"
+    },
+    {
+      "id": "filebrowser",
+      "type": "input",
+      "name": "Default File Browser",
+      "description": "default is 'nautilus', but you can change this to use a different file manager you have installed.",
+      "default_value": "nautilus"
+    },
+    {
+      "id": "texteditor",
+      "type": "input",
+      "name": "Default Text Editor",
+      "description": "Default is 'gedit', but you can change this to point to any other text editor you have installed",
+      "default_value": "gedit"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -50,7 +50,16 @@
       "name": "Default Text Editor",
       "description": "Default is 'gedit', but you can change this to point to any other text editor you have installed",
       "default_value": "gedit"
+    },
+    {
+      "id": "autowildcardsearch",
+      "type": "select",
+      "name": "Search Tracker and Locate with wildcards by default",
+      "description": "Automatically convert spaces to wildcards in tracker and locate (warning, may produce more matches)",
+      "default_value": "No",
+      "options": ["No", "Yes"]
     }
+    
   ]
 }
 


### PR DESCRIPTION
1 small bug fix + one feature addition request, pursuant to our previous chat: 
1. Small bug fix: the gnome-terminal option right at the bottom of the main.py file wasn't working for me when selecting a file, since the check for 'terminal' option that strips out the file path wasn't triggered. It should now be working.

2. Added a preferences setting in manifest.json to allow toggling wildcard searches in basic file name tracker search and in locate. It is disabled by default, so the behaviour of the extension should be identical to its default unless the user changes it. If the option is set, however, it inserts * wildcards into spaces between tracker or locate search key words

It looks like a lot of changes in the full files diff below, but it's actually only a few lines that were added (but due to indentation, diff says the entire blocks have changed). 

Please let me know any feedback or suggestions. 