### PR TITLE
ulauncher 5 patch: Create new 'upgrade' branch to contain py3 main.py file

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,19 +16,19 @@ from ulauncher.api.shared.action.RunScriptAction import RunScriptAction
 
 home = os.getenv("HOME")
 appPath = os.path.dirname(os.path.abspath(__file__))
-os.chmod(appPath + '/appchooser.py', 0755) 
+os.chmod(appPath + '/appchooser.py', 0o755) 
 
 def chunks(l, n):
-    """Yield successive n-sized chunks from l."""
-    for i in xrange(0, len(l), n):
-        yield l[i:i + n]
+	"""Yield successive n-sized chunks from l."""
+	for i in range(0, len(l), n):
+		yield l[i:i + n]
 
 def icon_path(*args):
-    for arg in args:
-        for size in [48]:
-            icon = icon_theme.choose_icon([arg], size, 0)
-            if icon is not None:
-                return icon.get_filename()
+	for arg in args:
+		for size in [48]:
+			icon = icon_theme.choose_icon([arg], size, 0)
+			if icon is not None:
+				return icon.get_filename()
 
 
 icon_theme = Gtk.IconTheme.get_default()
@@ -41,113 +41,113 @@ terminal_icon = icon_path('org.gnome.Terminal', 'terminal')
 
 class GnomeTrackerExtension(Extension):
 
-    def __init__(self):
-        super(GnomeTrackerExtension, self).__init__()
-        self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
-        self.subscribe(ItemEnterEvent, ItemEnterEventListener())
+	def __init__(self):
+		super(GnomeTrackerExtension, self).__init__()
+		self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
+		self.subscribe(ItemEnterEvent, ItemEnterEventListener())
 
 
 class KeywordQueryEventListener(EventListener):
 
-    def on_event(self, event, extension):
-        
-        keyword = event.get_keyword()
-        preferences = extension.preferences
-        query_words = event.get_argument()
-        if query_words == None:
-            query_words = ""
+	def on_event(self, event, extension):
+		
+		keyword = event.get_keyword()
+		preferences = extension.preferences
+		query_words = event.get_argument()
+		if query_words == None:
+			query_words = ""
 
-        if keyword == preferences["df_kw"]:
-            from search import search
-            out = search(query_words,28834)
-            output = [[doc.getFilename(),doc.getPathStr(),doc.getLastModifiedStr()] for doc in out]
-            results = sorted(output, key=lambda entry: entry[2])[::-1]
+		if keyword == preferences["df_kw"]:
+			from search import search
+			out = search(query_words,28834)
+			output = [[doc.getFilename(),doc.getPathStr(),doc.getLastModifiedStr()] for doc in out]
+			results = sorted(output, key=lambda entry: entry[2])[::-1]
 
-            items = []
-            for i in results:
-                data = '%s' %i[1]
-                items.append(ExtensionResultItem(icon='images/docfetcher.png',
-                                                 name='%s' %i[0],
-                                                 description="%s" %i[1],
-                                                 on_enter=ExtensionCustomAction(data, keep_app_open=True)))     
-        
-        else:
-            if keyword == preferences["gt_kw"]:
-                if preferences["autowildcardsearch"] == 'Yes':
-                    if " " in query_words: 
-                        query_words = "*".join(query_words.split(' ')) + "*"
-                    else:
-                        query_words = query_words + "*"
-                command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
-                output = subprocess.check_output(command)          
-                pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]
-                results = [[pre_results[i][0][2:],pre_results[i][1][7:]] for i in range(len(pre_results))]
+			items = []
+			for i in results:
+				data = '%s' %i[1]
+				items.append(ExtensionResultItem(icon='images/docfetcher.png',
+												 name='%s' %i[0],
+												 description="%s" %i[1],
+												 on_enter=ExtensionCustomAction(data, keep_app_open=True)))     
+		
+		else:
+			if keyword == preferences["gt_kw"]:
+				if preferences["autowildcardsearch"] == 'Yes':
+					if " " in query_words: 
+						query_words = "*".join(query_words.split(' ')) + "*"
+					else:
+						query_words = query_words + "*"
+				command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
+				output = subprocess.check_output(command)          
+				pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]
+				results = [[pre_results[i][0][2:],pre_results[i][1][7:]] for i in range(len(pre_results))]
 
-            elif keyword == preferences["ts_kw"]:
-                import re
+			elif keyword == preferences["ts_kw"]:
+				import re
 
-                out1 = subprocess.check_output(['tracker','search',query_words])
-                out2 = [i for i in out1.splitlines()]
-                out3 = [re.sub('\x1b[^m]*m', '', i).strip() for i in out2[1:]]
-                pre_results = list(chunks(out3,3))[:-1]
-                print(pre_results)
-                results = [[pre_results[i][1],pre_results[i][0][7:]] for i in range(len(pre_results))]
+				out1 = subprocess.check_output(['tracker','search',query_words])
+				out2 = [i for i in out1.splitlines()]
+				out3 = [re.sub('\x1b[^m]*m', '', i).strip() for i in out2[1:]]
+				pre_results = list(chunks(out3,3))[:-1]
+				print(pre_results)
+				results = [[pre_results[i][1],pre_results[i][0][7:]] for i in range(len(pre_results))]
 
-            elif keyword == preferences["lc_kw"]:
-                words = query_words.split(' ')
-                if len(words) == 1:
-                    output = subprocess.check_output(['locate','-l','11', query_words])
-                    pre_results = output.splitlines() 
-                    results = [[os.path.basename(i),i] for i in pre_results]
-                elif preferences["autowildcardsearch"] == 'No':                
-                    if len(words) == 3 and words[1] == 'g':
-                        loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
-                        output = subprocess.check_output(('grep','-m','11', words[2]), stdin=loc.stdout)
-                        pre_results = output.splitlines() 
-                        results = [[os.path.basename(i),i] for i in pre_results]
-                    elif len(words) == 5 and words[1] == 'g' and words [3] == 'g':
-                        loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
-                        grep1 = subprocess.Popen(('grep', words[2]),stdin=loc.stdout, stdout=subprocess.PIPE)
-                        output = subprocess.check_output(('grep','-m','11', words[4]), stdin=grep1.stdout)
-                        print(output)
-                        pre_results = output.splitlines() 
-                        results = [[os.path.basename(i),i] for i in pre_results]
-                # Do auto wildcard search if enabled in preferences
-                else:
-                    output = subprocess.check_output(['locate','-i','-l','11', "*" + "*".join(words) + "*"])
-                    pre_results = output.splitlines() 
-                    results = [[os.path.basename(i),i] for i in pre_results]
+			elif keyword == preferences["lc_kw"]:
+				words = query_words.split(' ')
+				if len(words) == 1:
+					output = subprocess.check_output(['locate','-l','11', query_words])
+					pre_results = output.splitlines() 
+					results = [[os.path.basename(i),i] for i in pre_results]
+				elif preferences["autowildcardsearch"] == 'No':                
+					if len(words) == 3 and words[1] == 'g':
+						loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
+						output = subprocess.check_output(('grep','-m','11', words[2]), stdin=loc.stdout)
+						pre_results = output.splitlines() 
+						results = [[os.path.basename(i),i] for i in pre_results]
+					elif len(words) == 5 and words[1] == 'g' and words [3] == 'g':
+						loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
+						grep1 = subprocess.Popen(('grep', words[2]),stdin=loc.stdout, stdout=subprocess.PIPE)
+						output = subprocess.check_output(('grep','-m','11', words[4]), stdin=grep1.stdout)
+						print(output)
+						pre_results = output.splitlines() 
+						results = [[os.path.basename(i),i] for i in pre_results]
+				# Do auto wildcard search if enabled in preferences
+				else:
+					output = subprocess.check_output(['locate','-i','-l','11', "*" + "*".join(words) + "*"])
+					pre_results = output.splitlines() 
+					results = [[os.path.basename(i),i] for i in pre_results]
 
 
-            items = []
-            for i in results:
-                data = '%s' %i[1]
-                items.append(ExtensionResultItem(icon='images/gnome.png',
-                                                 name='%s' %i[0],
-                                                 description="%s" %i[1],
-                                                 on_enter=ExtensionCustomAction(data, keep_app_open=True)))
-        return RenderResultListAction(items)
+			items = []
+			for i in results:
+				data = '%s' %i[1]
+				items.append(ExtensionResultItem(icon='images/gnome.png',
+												 name='%s' %i[0],
+												 description="%s" %i[1],
+												 on_enter=ExtensionCustomAction(data, keep_app_open=True)))
+		return RenderResultListAction(items)
 
 class ItemEnterEventListener(EventListener):
 
-    def on_event(self, event, extension):
-        appchooser_path = appPath + '/appchooser.py'
-        terminal = 'gnome-terminal --working-directory'
-        options = [['Open with default application', 'xdg-open','images/detective_penguin.png'],
-                   ['Open with other application', appchooser_path, other_application_icon],
-                   ['Open with file browser', extension.preferences["filebrowser"], file_browser_icon],
-                   ['Open with text editor', extension.preferences["texteditor"], text_editor_icon],
-                   ['Open location in terminal', terminal, terminal_icon]]
-        data = event.get_data().replace("%20"," ")
-        items = []
-        for i in options:
-            if i[1] == terminal:
-                data = os.path.dirname(os.path.abspath(data))
-            items.append(ExtensionResultItem(icon=i[2],
-                                             name='%s' %i[0],
-                                             description="%s" % data,
-                                             on_enter=RunScriptAction("%s '%s'" % (i[1], data), None)))
-        return RenderResultListAction(items)
+	def on_event(self, event, extension):
+		appchooser_path = appPath + '/appchooser.py'
+		terminal = 'gnome-terminal --working-directory'
+		options = [['Open with default application', 'xdg-open','images/detective_penguin.png'],
+				   ['Open with other application', appchooser_path, other_application_icon],
+				   ['Open with file browser', extension.preferences["filebrowser"], file_browser_icon],
+				   ['Open with text editor', extension.preferences["texteditor"], text_editor_icon],
+				   ['Open location in terminal', terminal, terminal_icon]]
+		data = event.get_data().replace("%20"," ")
+		items = []
+		for i in options:
+			if i[1] == terminal:
+				data = os.path.dirname(os.path.abspath(data))
+			items.append(ExtensionResultItem(icon=i[2],
+											 name='%s' %i[0],
+											 description="%s" % data,
+											 on_enter=RunScriptAction("%s '%s'" % (i[1], data), None)))
+		return RenderResultListAction(items)
 
 if __name__ == '__main__':
-    GnomeTrackerExtension().run()
+	GnomeTrackerExtension().run()

--- a/main.py
+++ b/main.py
@@ -79,7 +79,8 @@ class KeywordQueryEventListener(EventListener):
 					else:
 						query_words = query_words + "*"
 				command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
-				output = subprocess.check_output(command)          
+				output = subprocess.check_output(command)
+				print(output)
 				pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]
 				results = [[pre_results[i][0][2:],pre_results[i][1][7:]] for i in range(len(pre_results))]
 

--- a/main.py
+++ b/main.py
@@ -19,16 +19,16 @@ appPath = os.path.dirname(os.path.abspath(__file__))
 os.chmod(appPath + '/appchooser.py', 0o755) 
 
 def chunks(l, n):
-	"""Yield successive n-sized chunks from l."""
-	for i in range(0, len(l), n):
-		yield l[i:i + n]
+    """Yield successive n-sized chunks from l."""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
 
 def icon_path(*args):
-	for arg in args:
-		for size in [48]:
-			icon = icon_theme.choose_icon([arg], size, 0)
-			if icon is not None:
-				return icon.get_filename()
+    for arg in args:
+        for size in [48]:
+            icon = icon_theme.choose_icon([arg], size, 0)
+            if icon is not None:
+                return icon.get_filename()
 
 
 icon_theme = Gtk.IconTheme.get_default()
@@ -41,114 +41,113 @@ terminal_icon = icon_path('org.gnome.Terminal', 'terminal')
 
 class GnomeTrackerExtension(Extension):
 
-	def __init__(self):
-		super(GnomeTrackerExtension, self).__init__()
-		self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
-		self.subscribe(ItemEnterEvent, ItemEnterEventListener())
+    def __init__(self):
+        super(GnomeTrackerExtension, self).__init__()
+        self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
+        self.subscribe(ItemEnterEvent, ItemEnterEventListener())
 
 
 class KeywordQueryEventListener(EventListener):
 
-	def on_event(self, event, extension):
-		
-		keyword = event.get_keyword()
-		preferences = extension.preferences
-		query_words = event.get_argument()
-		if query_words == None:
-			query_words = ""
+    def on_event(self, event, extension):
+        
+        keyword = event.get_keyword()
+        preferences = extension.preferences
+        query_words = event.get_argument()
+        if query_words == None:
+            query_words = ""
 
-		if keyword == preferences["df_kw"]:
-			from search import search
-			out = search(query_words,28834)
-			output = [[doc.getFilename(),doc.getPathStr(),doc.getLastModifiedStr()] for doc in out]
-			results = sorted(output, key=lambda entry: entry[2])[::-1]
+        if keyword == preferences["df_kw"]:
+            from search import search
+            out = search(query_words,28834)
+            output = [[doc.getFilename(),doc.getPathStr(),doc.getLastModifiedStr()] for doc in out]
+            results = sorted(output, key=lambda entry: entry[2])[::-1]
 
-			items = []
-			for i in results:
-				data = '%s' %i[1]
-				items.append(ExtensionResultItem(icon='images/docfetcher.png',
-												 name='%s' %i[0],
-												 description="%s" %i[1],
-												 on_enter=ExtensionCustomAction(data, keep_app_open=True)))     
-		
-		else:
-			if keyword == preferences["gt_kw"]:
-				if preferences["autowildcardsearch"] == 'Yes':
-					if " " in query_words: 
-						query_words = "*".join(query_words.split(' ')) + "*"
-					else:
-						query_words = query_words + "*"
-				command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
-				output = subprocess.check_output(command)
-				print(output)
-				pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]
-				results = [[pre_results[i][0][2:],pre_results[i][1][7:]] for i in range(len(pre_results))]
+            items = []
+            for i in results:
+                data = '%s' %i[1]
+                items.append(ExtensionResultItem(icon='images/docfetcher.png',
+                                                 name='%s' %i[0],
+                                                 description="%s" %i[1],
+                                                 on_enter=ExtensionCustomAction(data, keep_app_open=True)))     
+        
+        else:
+            if keyword == preferences["gt_kw"]:
+                if preferences["autowildcardsearch"] == 'Yes':
+                    if " " in query_words: 
+                        query_words = "*".join(query_words.split(' ')) + "*"
+                    else:
+                        query_words = query_words + "*"
+                command = ['tracker', 'sparql', '-q', "SELECT nfo:fileName(?f) nie:url(?f) WHERE { ?f nie:url ?url FILTER(fn:starts-with(?url, \'file://" + home + "/\')) . ?f fts:match '"+query_words+"' } ORDER BY nfo:fileLastAccessed(?f)"]
+                output = subprocess.check_output(command, encoding='UTF-8')
+                pre_results = [i.split(', ') for i in output.splitlines()][::-1][1:-1][:20]
+                results = [[pre_results[i][0][2:],pre_results[i][1][7:]] for i in range(len(pre_results))]
 
-			elif keyword == preferences["ts_kw"]:
-				import re
+            elif keyword == preferences["ts_kw"]:
+                import re
 
-				out1 = subprocess.check_output(['tracker','search',query_words])
-				out2 = [i for i in out1.splitlines()]
-				out3 = [re.sub('\x1b[^m]*m', '', i).strip() for i in out2[1:]]
-				pre_results = list(chunks(out3,3))[:-1]
-				print(pre_results)
-				results = [[pre_results[i][1],pre_results[i][0][7:]] for i in range(len(pre_results))]
+                out1 = subprocess.check_output(['tracker','search',query_words], encoding='UTF-8')
+                out2 = [i for i in out1.splitlines()]
+                out3 = [re.sub('\x1b[^m]*m', '', i).strip() for i in out2[1:]]
+                pre_results = list(chunks(out3,3))[:-1]
+                print(pre_results)
+                results = [[pre_results[i][1],pre_results[i][0][7:]] for i in range(len(pre_results))]
 
-			elif keyword == preferences["lc_kw"]:
-				words = query_words.split(' ')
-				if len(words) == 1:
-					output = subprocess.check_output(['locate','-l','11', query_words])
-					pre_results = output.splitlines() 
-					results = [[os.path.basename(i),i] for i in pre_results]
-				elif preferences["autowildcardsearch"] == 'No':                
-					if len(words) == 3 and words[1] == 'g':
-						loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
-						output = subprocess.check_output(('grep','-m','11', words[2]), stdin=loc.stdout)
-						pre_results = output.splitlines() 
-						results = [[os.path.basename(i),i] for i in pre_results]
-					elif len(words) == 5 and words[1] == 'g' and words [3] == 'g':
-						loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
-						grep1 = subprocess.Popen(('grep', words[2]),stdin=loc.stdout, stdout=subprocess.PIPE)
-						output = subprocess.check_output(('grep','-m','11', words[4]), stdin=grep1.stdout)
-						print(output)
-						pre_results = output.splitlines() 
-						results = [[os.path.basename(i),i] for i in pre_results]
-				# Do auto wildcard search if enabled in preferences
-				else:
-					output = subprocess.check_output(['locate','-i','-l','11', "*" + "*".join(words) + "*"])
-					pre_results = output.splitlines() 
-					results = [[os.path.basename(i),i] for i in pre_results]
+            elif keyword == preferences["lc_kw"]:
+                words = query_words.split(' ')
+                if len(words) == 1:
+                    output = subprocess.check_output(['locate','-l','11', query_words], encoding='UTF-8')
+                    pre_results = output.splitlines() 
+                    results = [[os.path.basename(i),i] for i in pre_results]
+                elif preferences["autowildcardsearch"] == 'No':                
+                    if len(words) == 3 and words[1] == 'g':
+                        loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
+                        output = subprocess.check_output(('grep','-m','11', words[2]), stdin=loc.stdout, encoding='UTF-8')
+                        pre_results = output.splitlines() 
+                        results = [[os.path.basename(i),i] for i in pre_results]
+                    elif len(words) == 5 and words[1] == 'g' and words [3] == 'g':
+                        loc = subprocess.Popen(('locate', words[0]), stdout=subprocess.PIPE)
+                        grep1 = subprocess.Popen(('grep', words[2]),stdin=loc.stdout, stdout=subprocess.PIPE)
+                        output = subprocess.check_output(('grep','-m','11', words[4]), stdin=grep1.stdout, encoding='UTF-8')
+                        print(output)
+                        pre_results = output.splitlines() 
+                        results = [[os.path.basename(i),i] for i in pre_results]
+                # Do auto wildcard search if enabled in preferences
+                else:
+                    output = subprocess.check_output(['locate','-i','-l','11', "*" + "*".join(words) + "*"], encoding='UTF-8')
+                    pre_results = output.splitlines() 
+                    results = [[os.path.basename(i),i] for i in pre_results]
 
 
-			items = []
-			for i in results:
-				data = '%s' %i[1]
-				items.append(ExtensionResultItem(icon='images/gnome.png',
-												 name='%s' %i[0],
-												 description="%s" %i[1],
-												 on_enter=ExtensionCustomAction(data, keep_app_open=True)))
-		return RenderResultListAction(items)
+            items = []
+            for i in results:
+                data = '%s' %i[1]
+                items.append(ExtensionResultItem(icon='images/gnome.png',
+                                                 name='%s' %i[0],
+                                                 description="%s" %i[1],
+                                                 on_enter=ExtensionCustomAction(data, keep_app_open=True)))
+        return RenderResultListAction(items)
 
 class ItemEnterEventListener(EventListener):
 
-	def on_event(self, event, extension):
-		appchooser_path = appPath + '/appchooser.py'
-		terminal = 'gnome-terminal --working-directory'
-		options = [['Open with default application', 'xdg-open','images/detective_penguin.png'],
-				   ['Open with other application', appchooser_path, other_application_icon],
-				   ['Open with file browser', extension.preferences["filebrowser"], file_browser_icon],
-				   ['Open with text editor', extension.preferences["texteditor"], text_editor_icon],
-				   ['Open location in terminal', terminal, terminal_icon]]
-		data = event.get_data().replace("%20"," ")
-		items = []
-		for i in options:
-			if i[1] == terminal:
-				data = os.path.dirname(os.path.abspath(data))
-			items.append(ExtensionResultItem(icon=i[2],
-											 name='%s' %i[0],
-											 description="%s" % data,
-											 on_enter=RunScriptAction("%s '%s'" % (i[1], data), None)))
-		return RenderResultListAction(items)
+    def on_event(self, event, extension):
+        appchooser_path = appPath + '/appchooser.py'
+        terminal = 'gnome-terminal --working-directory'
+        options = [['Open with default application', 'xdg-open','images/detective_penguin.png'],
+                   ['Open with other application', appchooser_path, other_application_icon],
+                   ['Open with file browser', extension.preferences["filebrowser"], file_browser_icon],
+                   ['Open with text editor', extension.preferences["texteditor"], text_editor_icon],
+                   ['Open location in terminal', terminal, terminal_icon]]
+        data = event.get_data().replace("%20"," ")
+        items = []
+        for i in options:
+            if i[1] == terminal:
+                data = os.path.dirname(os.path.abspath(data))
+            items.append(ExtensionResultItem(icon=i[2],
+                                             name='%s' %i[0],
+                                             description="%s" % data,
+                                             on_enter=RunScriptAction("%s '%s'" % (i[1], data), None)))
+        return RenderResultListAction(items)
 
 if __name__ == '__main__':
-	GnomeTrackerExtension().run()
+    GnomeTrackerExtension().run()

--- a/manifest.json
+++ b/manifest.json
@@ -1,64 +1,64 @@
 {
-	"required_api_version": "^2.0.0",
-	"name": "Gnome tracker",
-	"description": "Deep search files using gnome tracker",
-	"developer_name": "Daniel Nicolai  !!! CHECK README FILE TO ENABLE FULL FUNCTIONALITY, e.g. open with !!!",
-	"icon": "images/detective_penguin.png",
-	"options": {
-		"query_debounce": 0.1
-	},
-	"preferences": [
-		{
-			"id": "gt_kw",
-			"type": "keyword",
-			"name": "Gnome tracker",
-			"description": "Deep search files using gnome tracker",
-			"default_value": "gt"
-		},
-		{
-			"id": "ts_kw",
-			"type": "keyword",
-			"name": "Tracker search",
-			"description": "Deep search files using tracker search",
-			"default_value": "ts"
-		},
-		{
-			"id": "df_kw",
-			"type": "keyword",
-			"name": "DocFetcher",
-			"description": "Deep search files using DocFetcher",
-			"default_value": "df"
-		},
-		{
-			"id": "lc_kw",
-			"type": "keyword",
-			"name": "locate",
-			"description": "Instantly find files using locate command",
-			"default_value": "lc"
-		},
-		{
-			"id": "filebrowser",
-			"type": "input",
-			"name": "Default File Browser",
-			"description": "default is 'nautilus', but you can change this to use a different file manager you have installed.",
-			"default_value": "nautilus"
-		},
-		{
-			"id": "texteditor",
-			"type": "input",
-			"name": "Default Text Editor",
-			"description": "Default is 'gedit', but you can change this to point to any other text editor you have installed",
-			"default_value": "gedit"
-		},
-		{
-			"id": "autowildcardsearch",
-			"type": "select",
-			"name": "Search Tracker and Locate with wildcards by default",
-			"description": "Automatically convert spaces to wildcards in tracker and locate (warning, may produce more matches)",
-			"default_value": "No",
-			"options": ["No", "Yes"]
-		}
-		
-	]
+  "required_api_version": "^2.0.0",
+  "name": "Gnome tracker",
+  "description": "Deep search files using gnome tracker",
+  "developer_name": "Daniel Nicolai  !!! CHECK README FILE TO ENABLE FULL FUNCTIONALITY, e.g. open with !!!",
+  "icon": "images/detective_penguin.png",
+  "options": {
+    "query_debounce": 0.1
+  },
+  "preferences": [
+    {
+      "id": "gt_kw",
+      "type": "keyword",
+      "name": "Gnome tracker",
+      "description": "Deep search files using gnome tracker",
+      "default_value": "gt"
+    },
+    {
+      "id": "ts_kw",
+      "type": "keyword",
+      "name": "Tracker search",
+      "description": "Deep search files using tracker search",
+      "default_value": "ts"
+    },
+    {
+      "id": "df_kw",
+      "type": "keyword",
+      "name": "DocFetcher",
+      "description": "Deep search files using DocFetcher",
+      "default_value": "df"
+    },
+    {
+      "id": "lc_kw",
+      "type": "keyword",
+      "name": "locate",
+      "description": "Instantly find files using locate command",
+      "default_value": "lc"
+    },
+    {
+      "id": "filebrowser",
+      "type": "input",
+      "name": "Default File Browser",
+      "description": "default is 'nautilus', but you can change this to use a different file manager you have installed.",
+      "default_value": "nautilus"
+    },
+    {
+      "id": "texteditor",
+      "type": "input",
+      "name": "Default Text Editor",
+      "description": "Default is 'gedit', but you can change this to point to any other text editor you have installed",
+      "default_value": "gedit"
+    },
+    {
+      "id": "autowildcardsearch",
+      "type": "select",
+      "name": "Search Tracker and Locate with wildcards by default",
+      "description": "Automatically convert spaces to wildcards in tracker and locate (warning, may produce more matches)",
+      "default_value": "No",
+      "options": ["No", "Yes"]
+    }
+    
+  ]
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,65 +1,64 @@
 {
-  "manifest_version": "2",
-  "api_version": "1",
-  "name": "Gnome tracker",
-  "description": "Deep search files using gnome tracker",
-  "developer_name": "Daniel Nicolai  !!! CHECK README FILE TO ENABLE FULL FUNCTIONALITY, e.g. open with !!!",
-  "icon": "images/detective_penguin.png",
-  "options": {
-    "query_debounce": 0.1
-  },
-  "preferences": [
-    {
-      "id": "gt_kw",
-      "type": "keyword",
-      "name": "Gnome tracker",
-      "description": "Deep search files using gnome tracker",
-      "default_value": "gt"
-    },
-    {
-      "id": "ts_kw",
-      "type": "keyword",
-      "name": "Tracker search",
-      "description": "Deep search files using tracker search",
-      "default_value": "ts"
-    },
-    {
-      "id": "df_kw",
-      "type": "keyword",
-      "name": "DocFetcher",
-      "description": "Deep search files using DocFetcher",
-      "default_value": "df"
-    },
-    {
-      "id": "lc_kw",
-      "type": "keyword",
-      "name": "locate",
-      "description": "Instantly find files using locate command",
-      "default_value": "lc"
-    },
-    {
-      "id": "filebrowser",
-      "type": "input",
-      "name": "Default File Browser",
-      "description": "default is 'nautilus', but you can change this to use a different file manager you have installed.",
-      "default_value": "nautilus"
-    },
-    {
-      "id": "texteditor",
-      "type": "input",
-      "name": "Default Text Editor",
-      "description": "Default is 'gedit', but you can change this to point to any other text editor you have installed",
-      "default_value": "gedit"
-    },
-    {
-      "id": "autowildcardsearch",
-      "type": "select",
-      "name": "Search Tracker and Locate with wildcards by default",
-      "description": "Automatically convert spaces to wildcards in tracker and locate (warning, may produce more matches)",
-      "default_value": "No",
-      "options": ["No", "Yes"]
-    }
-    
-  ]
+	"required_api_version": "^2.0.0",
+	"name": "Gnome tracker",
+	"description": "Deep search files using gnome tracker",
+	"developer_name": "Daniel Nicolai  !!! CHECK README FILE TO ENABLE FULL FUNCTIONALITY, e.g. open with !!!",
+	"icon": "images/detective_penguin.png",
+	"options": {
+		"query_debounce": 0.1
+	},
+	"preferences": [
+		{
+			"id": "gt_kw",
+			"type": "keyword",
+			"name": "Gnome tracker",
+			"description": "Deep search files using gnome tracker",
+			"default_value": "gt"
+		},
+		{
+			"id": "ts_kw",
+			"type": "keyword",
+			"name": "Tracker search",
+			"description": "Deep search files using tracker search",
+			"default_value": "ts"
+		},
+		{
+			"id": "df_kw",
+			"type": "keyword",
+			"name": "DocFetcher",
+			"description": "Deep search files using DocFetcher",
+			"default_value": "df"
+		},
+		{
+			"id": "lc_kw",
+			"type": "keyword",
+			"name": "locate",
+			"description": "Instantly find files using locate command",
+			"default_value": "lc"
+		},
+		{
+			"id": "filebrowser",
+			"type": "input",
+			"name": "Default File Browser",
+			"description": "default is 'nautilus', but you can change this to use a different file manager you have installed.",
+			"default_value": "nautilus"
+		},
+		{
+			"id": "texteditor",
+			"type": "input",
+			"name": "Default Text Editor",
+			"description": "Default is 'gedit', but you can change this to point to any other text editor you have installed",
+			"default_value": "gedit"
+		},
+		{
+			"id": "autowildcardsearch",
+			"type": "select",
+			"name": "Search Tracker and Locate with wildcards by default",
+			"description": "Automatically convert spaces to wildcards in tracker and locate (warning, may produce more matches)",
+			"default_value": "No",
+			"options": ["No", "Yes"]
+		}
+		
+	]
 }
 

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,4 @@
 [
   { "required_api_version": "^1.0.0", "commit": "master" },
-  { "required_api_version": "^2.0.0", "commit": "devel" }
+  { "required_api_version": "^2.0.0", "commit": "upgrade" }
 ]

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "master" },
+  { "required_api_version": "^2.0.0", "commit": "devel" }
+]


### PR DESCRIPTION
#7 Have made some changes to the main.py file to make it compatible with python3, notably:

- chmod needs to be '0o755' in py3 (by the way, I had a question @dalanicolai - why does the extension require a chmod of appchooser.py?)

- replaced xrange with range for py3 compatibility

- modified all subprocess.check_output to have "encoding='UTF-8'" option (otherwise py3 returns a byte object rather than str, as in py2, which seems to choke on splitlines).

Have tested this on my local ulauncher 5 install and it seems to work. Haven't tested yet on ulauncher 4, though since the 'upgrade' branch py file is separate from the 'master' branch, this shouldn't cause any issues for backwards compatibility. 